### PR TITLE
Don't reload steps in StartListening

### DIFF
--- a/src/cucumber.lua
+++ b/src/cucumber.lua
@@ -112,7 +112,6 @@ function CucumberLua:StartListening ()
   local ip, port = sock:getsockname()
   assert(ip, port)
   print("Waiting for cucumber on " .. ip .. ":" .. port .. " (Ctrl+C to quit)")
-  self:ReloadSteps()
   self:Listen(sock)
 end
 


### PR DESCRIPTION
Doing so will result in ReloadSteps being called twice the first time.
This will create double Before hooks for instance.
