### PR TITLE
Fix global response

### DIFF
--- a/src/cucumber.lua
+++ b/src/cucumber.lua
@@ -81,7 +81,7 @@ end
 function CucumberLua:RespondToWireRequest (request)
   local command = request[1]
   local args = request[2]
-  response = { "success" }
+  local response = { "success" }
   if self[command] then
     response = self[command](self, args)
   end


### PR DESCRIPTION
When responding to a wire request the actual response is stored in a global variable called response. I assume there's a missing 'local' in front of that variable declaration. What do you think @joshski ?
